### PR TITLE
fix: 修正content display title 的邏輯

### DIFF
--- a/src/components/post/Content.jsx
+++ b/src/components/post/Content.jsx
@@ -17,15 +17,14 @@ const MarkdownContent = ({ content }) => {
 }
 
 const PrimaryContent = ({ content }) => {
-  if (content.displayTitle) {
-    return (
-      <div id={`content-${content.id}`}>
-        <h2 className="mt-12 mb-6">{content.title}</h2>
-        {content?.content && <MarkdownContent content={content} />}
-      </div>
-    )
-  }
-  return null
+  return (
+    <div id={`content-${content.id}`}>
+      <h2 className={`mt-12 mb-6 ${content.displayTitle ? "" : "hidden"}`}>
+        {content.title}
+      </h2>
+      {content?.content && <MarkdownContent content={content} />}
+    </div>
+  )
 }
 
 const SecondaryContent = ({ content }) => {


### PR DESCRIPTION
原本displaytitle false 會將內文也隱藏起來 應該是只隱藏 標題 內文正常顯示